### PR TITLE
ramips: rt3833: fix build breakage

### DIFF
--- a/target/linux/ramips/image/rt3883.mk
+++ b/target/linux/ramips/image/rt3883.mk
@@ -33,7 +33,7 @@ define Device/cy-swr1100
 	seama-seal -m "signature=wrgnd10_samsung_ss815" | \
 	check-size $$$$(IMAGE_SIZE)
   DEVICE_TITLE := Samsung CY-SWR1100
-  DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 | \
+  DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2 \
 	kmod-usb-ledtrig-usbport swconfig
 endef
 TARGET_DEVICES += cy-swr1100


### PR DESCRIPTION
Commit 60f41c6c9ef6 ("ramips: add usb-ledtrig-usbport to DEVICE_PACKAGES
of CY-SWR1100") added stray | during backport which caused build
breakage on the buildbots:

 bash: -c: line 0: syntax error near unexpected token `|'
 bash: -c: line 0: `echo kmod-usb-core kmod-usb-ledtrig-usbport kmod-usb-ohci kmod-usb2 swconfig | | mkhash md5 | head -c 8'

Fixes: 60f41c6c9ef6 ("ramips: add usb-ledtrig-usbport to DEVICE_PACKAGES of CY-SWR1100")
Signed-off-by: Petr Štetiar <ynezz@true.cz>
(cherry picked from commit a1ff175dbf807925a0bae537935455bd1aa44a98)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
