### PR TITLE
ramips: assign correct key-code to wps buttons

### DIFF
--- a/target/linux/ramips/dts/WL-330N.dts
+++ b/target/linux/ramips/dts/WL-330N.dts
@@ -38,7 +38,7 @@
 		wps {
 			label = "wps";
 			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
+			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
 };

--- a/target/linux/ramips/dts/WL-330N3G.dts
+++ b/target/linux/ramips/dts/WL-330N3G.dts
@@ -43,7 +43,7 @@
 		wps {
 			label = "wps";
 			gpios = <&gpio0 0 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
+			linux,code = <KEY_WPS_BUTTON>;
 		};
 	};
 };


### PR DESCRIPTION
The two ASUS WL-330N and WL-330N3G had the reset keycode
assigned to the WPS button. This patch changes both devices
to use KEY_WPS_BUTTON in the hopes that this fixes unwanted
restarts/ unexpected behavior from the users point of view.

[dropped RG21S]
Signed-off-by: Christian Lamparter <chunkeey@gmail.com>
(cherry picked from commit ad65d9d7b264d6d17293c59469e770905d2f785a)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
