### PR TITLE
base-files: config_generate: split macaddr with multiple ifaces

### DIFF
--- a/package/base-files/Makefile
+++ b/package/base-files/Makefile
@@ -12,7 +12,7 @@ include $(INCLUDE_DIR)/version.mk
 include $(INCLUDE_DIR)/feeds.mk
 
 PKG_NAME:=base-files
-PKG_RELEASE:=194.2
+PKG_RELEASE:=194.3
 PKG_FLAGS:=nonshared
 
 PKG_FILE_DEPENDS:=$(PLATFORM_DIR)/ $(GENERIC_PLATFORM_DIR)/base-files/

--- a/package/base-files/files/bin/config_generate
+++ b/package/base-files/files/bin/config_generate
@@ -85,12 +85,16 @@ generate_network() {
 		set network.$1.proto='none'
 	EOF
 
-	[ -n "$macaddr" ] && uci -q batch <<-EOF
-		delete network.$1_dev
-		set network.$1_dev='device'
-		set network.$1_dev.name='$ifname'
-		set network.$1_dev.macaddr='$macaddr'
-	EOF
+	if [ -n "$macaddr" ]; then
+		for name in $ifname; do
+			uci -q batch <<-EOF
+				delete network.$1_${name/./_}_dev
+				set network.$1_${name/./_}_dev='device'
+				set network.$1_${name/./_}_dev.name='$name'
+				set network.$1_${name/./_}_dev.macaddr='$macaddr'
+			EOF
+		done
+	fi
 
 	case "$protocol" in
 		static)


### PR DESCRIPTION
netifd does not handle network.@device[x].name properly if it
contains multiple ifaces separated by spaces. Due to this, board.d
lan_mac setup does not work if multiple ifaces are set to LAN by
ucidef_set_interface_lan.

To fix this, create a device node for each member iface when
running config_generate instead. Those are named based on the
member ifname:

  ucidef_set_interface_lan "eth0 eth1.1"
  ucidef_set_interface_macaddr "lan" "yy:yy:yy:yy:yy:01"

will return

  config device 'lan_eth0_dev'
        option name 'eth0'
        option macaddr 'yy:yy:yy:yy:yy:01'

  config device 'lan_eth1_1_dev'
        option name 'eth1.1'
        option macaddr 'yy:yy:yy:yy:yy:01'

ref: https://github.com/openwrt/openwrt/pull/2542

Signed-off-by: Sungbo Eo <mans0n@gorani.run>
[always use new scheme, extend description, change commit title]
Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
(cherry picked from commit 298814e6be7640d89328de9e7c90d4349e30683f)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
