### PR TITLE
mac80211: Adapt to changes to skb_get_hash_perturb()

### DIFF
--- a/package/kernel/mac80211/patches/370-backports-Adapt-to-changes-to-skb_get_hash_perturb.patch
+++ b/package/kernel/mac80211/patches/370-backports-Adapt-to-changes-to-skb_get_hash_perturb.patch
@@ -1,0 +1,68 @@
+From e3c57dd949835419cee8d3b45db38de58bf6ebd5 Mon Sep 17 00:00:00 2001
+From: Hauke Mehrtens <hauke@hauke-m.de>
+Date: Mon, 18 Nov 2019 01:13:37 +0100
+Subject: [PATCH] backports: Adapt to changes to skb_get_hash_perturb()
+
+The skb_get_hash_perturb() function now takes a siphash_key_t instead of
+an u32. This was changed in commit 55667441c84f ("net/flow_dissector:
+switch to siphash"). Use the correct type in the fq header file
+depending on the kernel version.
+
+Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
+---
+ include/net/fq.h      | 8 ++++++++
+ include/net/fq_impl.h | 8 ++++++++
+ 2 files changed, 16 insertions(+)
+
+--- a/include/net/fq.h
++++ b/include/net/fq.h
+@@ -70,7 +70,15 @@ struct fq {
+ 	struct list_head backlogs;
+ 	spinlock_t lock;
+ 	u32 flows_cnt;
++#if LINUX_VERSION_IS_GEQ(5,3,10) || \
++    LINUX_VERSION_IN_RANGE(4,19,83, 4,20,0) || \
++    LINUX_VERSION_IN_RANGE(4,14,153, 4,15,0) || \
++    LINUX_VERSION_IN_RANGE(4,9,200, 4,10,0) || \
++    LINUX_VERSION_IN_RANGE(4,4,200, 4,5,0)
++	siphash_key_t	perturbation;
++#else
+ 	u32 perturbation;
++#endif
+ 	u32 limit;
+ 	u32 memory_limit;
+ 	u32 memory_usage;
+--- a/include/net/fq_impl.h
++++ b/include/net/fq_impl.h
+@@ -118,7 +118,15 @@ static struct fq_flow *fq_flow_classify(
+ 
+ 	lockdep_assert_held(&fq->lock);
+ 
++#if LINUX_VERSION_IS_GEQ(5,3,10) || \
++    LINUX_VERSION_IN_RANGE(4,19,83, 4,20,0) || \
++    LINUX_VERSION_IN_RANGE(4,14,153, 4,15,0) || \
++    LINUX_VERSION_IN_RANGE(4,9,200, 4,10,0) || \
++    LINUX_VERSION_IN_RANGE(4,4,200, 4,5,0)
++	hash = skb_get_hash_perturb(skb, &fq->perturbation);
++#else
+ 	hash = skb_get_hash_perturb(skb, fq->perturbation);
++#endif
+ 	idx = reciprocal_scale(hash, fq->flows_cnt);
+ 	flow = &fq->flows[idx];
+ 
+@@ -307,7 +315,15 @@ static int fq_init(struct fq *fq, int fl
+ 	INIT_LIST_HEAD(&fq->backlogs);
+ 	spin_lock_init(&fq->lock);
+ 	fq->flows_cnt = max_t(u32, flows_cnt, 1);
++#if LINUX_VERSION_IS_GEQ(5,3,10) || \
++    LINUX_VERSION_IN_RANGE(4,19,83, 4,20,0) || \
++    LINUX_VERSION_IN_RANGE(4,14,153, 4,15,0) || \
++    LINUX_VERSION_IN_RANGE(4,9,200, 4,10,0) || \
++    LINUX_VERSION_IN_RANGE(4,4,200, 4,5,0)
++	get_random_bytes(&fq->perturbation, sizeof(fq->perturbation));
++#else
+ 	fq->perturbation = prandom_u32();
++#endif
+ 	fq->quantum = 300;
+ 	fq->limit = 8192;
+ 	fq->memory_limit = 16 << 20; /* 16 MBytes */


### PR DESCRIPTION
The skb_get_hash_perturb() function now takes a siphash_key_t instead of
an u32. This was changed in commit 55667441c84f ("net/flow_dissector:
switch to siphash"). Use the correct type in the fq header file
depending on the kernel version.

Signed-off-by: Hauke Mehrtens <hauke@hauke-m.de>
Signed-off-by: Stefan Lippers-Hollmann <s.l-h@gmx.de>
(cherry picked from commit eaa047179ad30d156d0c3da7ec225acfae7a9f00)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
