### PR TITLE
ar71xx: fix MAC address setup for TL-WDR4300 board

### DIFF
--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
+++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
@@ -605,6 +605,10 @@ ar71xx_setup_macs()
 	fritz300e)
 		lan_mac=$(fritz_tffs -n maca -i $(find_mtd_part "tffs (1)"))
 		;;
+	tl-wdr4300)
+		base_mac=$(mtd_get_mac_binary u-boot 0x1fc00)
+		wan_mac=$(macaddr_add "$base_mac" 1)
+		;;
 	tl-wr1043n-v5|\
 	tl-wr1043nd-v4)
 		lan_mac=$(mtd_get_mac_binary product-info 8)

--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wdr4300.c
+++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wdr4300.c
@@ -183,7 +183,7 @@ static void __init wdr4300_setup(void)
 
 	ath79_register_mdio(0, 0x0);
 
-	ath79_init_mac(ath79_eth0_data.mac_addr, mac, -2);
+	ath79_init_mac(ath79_eth0_data.mac_addr, mac, 0);
 
 	/* GMAC0 is connected to an AR8327N switch */
 	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;


### PR DESCRIPTION
The current ethernet MAC address setup of TL-WDR4300 board is different
from the setup of stock firmware:

OpenWrt: lan = label_mac -2, wan = label_mac -2
  stock: lan = label_mac,    wan = label_mac +1

This patch applies to all devices using TL-WDR4300 board:
TL-WDR3600 v1
TL-WDR4300 v1
TL-WDR4300 v1 (IL)
TL-WDR4310 v1
Mercury MW4530R v1

Signed-off-by: Sungbo Eo <mans0n@gorani.run>
(cherry picked from commit 9b02d32e34df2bb8821ec6f08f525bee22d0d1ba)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
