### PR TITLE
ramips: fix inverted reset button for Ravpower WD03

### DIFF
--- a/target/linux/ramips/dts/WD03.dts
+++ b/target/linux/ramips/dts/WD03.dts
@@ -36,7 +36,7 @@
 
 		reset {
 			label = "reset";
-			gpios = <&gpio2 1 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpio2 1 GPIO_ACTIVE_LOW>;
 			linux,code = <KEY_RESTART>;
 		};
 	};


### PR DESCRIPTION
The button events "pressed" and "released" were switched. Tested with v18.06.4.

Signed-off-by: Moritz Warning <moritzwarning@web.de>
(cherry picked from commit 3e1325b219fced91f01d5594503f61d326a93b90)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
