### PR TITLE
ath79: gl-ar750s: reduce kernel size to 2M in image Makefile

### DIFF
--- a/target/linux/ath79/image/nand.mk
+++ b/target/linux/ath79/image/nand.mk
@@ -82,7 +82,7 @@ define Device/glinet_gl-ar750s-common
   DEVICE_MODEL := GL-AR750S
   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9887-ct kmod-usb2 \
 	kmod-usb-storage block-mount
-  KERNEL_SIZE := 4096k
+  KERNEL_SIZE := 2048k
   IMAGE_SIZE := 16000k
   PAGESIZE := 2048
   VID_HDR_OFFSET := 2048


### PR DESCRIPTION
u-boot splits nand factory firmware at 2M offset, flash the first
part as kernel into spi nor and the other part as ubi into nand
flash. With previous commit increasing kernel size to 4M, generated
factory firmware is broken because ubi is at 4M offset.

This commit reduces kernel size definition to 2M in image Makefile,
producing proper factory image. Partition size in dts is kept
unchanged so that sysupgrade to a firmware with 2M+ kernel still
works.

Fixes: b496a2294c ("ath79: GL-AR750S: provide NAND support; increase kernel to 4 MB")
Reported-by: Jeff Kletsky <git-commits@allycomm.com>
Signed-off-by: Chuanhong Guo <gch981213@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
