### PR TITLE
hostapd: cleanup IBSS-RSN

### DIFF
--- a/package/network/services/hostapd/Makefile
+++ b/package/network/services/hostapd/Makefile
@@ -7,7 +7,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=hostapd
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_URL:=http://w1.fi/hostap.git
 PKG_SOURCE_PROTO:=git

--- a/package/network/services/hostapd/files/hostapd.sh
+++ b/package/network/services/hostapd/files/hostapd.sh
@@ -704,12 +704,9 @@ wpa_supplicant_prepare_interface() {
 	local ap_scan=
 
 	_w_mode="$mode"
-	_w_modestr=
 
 	[[ "$mode" = adhoc ]] && {
 		ap_scan="ap_scan=2"
-
-		_w_modestr="mode=1"
 	}
 
 	local country_str=
@@ -790,6 +787,7 @@ wpa_supplicant_add_network() {
 	[[ "$_w_mode" = "adhoc" ]] && {
 		append network_data "mode=1" "$N$T"
 		[ -n "$freq" ] && wpa_supplicant_set_fixed_freq "$freq" "$htmode"
+		[ "$noscan" = "1" ] && append network_data "noscan=1" "$N$T"
 
 		scan_ssid="scan_ssid=0"
 
@@ -808,8 +806,6 @@ wpa_supplicant_add_network() {
 		append wpa_key_mgmt "SAE"
 		scan_ssid=""
 	}
-
-	[ "$_w_mode" = "adhoc" -o "$_w_mode" = "mesh" ] && append network_data "$_w_modestr" "$N$T"
 
 	[ "$multi_ap" = 1 -a "$_w_mode" = "sta" ] && append network_data "multi_ap_backhaul_sta=1" "$N$T"
 


### PR DESCRIPTION
set noscan also for IBSS and remove redundant/obsolete variable.

Signed-off-by: Daniel Golle <daniel@makrotopia.org>
(cherry picked from commit 702c70264b388c2b47e171843f297f43c71b86b9)

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
